### PR TITLE
Server game pagination update

### DIFF
--- a/server/db/games.js
+++ b/server/db/games.js
@@ -119,27 +119,15 @@ function getGameById (gameId) {
 }
 
 function sortGames (gameA, gameB) {
-  const versionA = gameA.version
-  const versionB = gameB.version
   const dateA = new Date(gameA.created_at)
   const dateB = new Date(gameB.created_at)
-  if (versionA === versionB) {
-    if (dateA > dateB) {
-      return -1
-    }
-    if (dateA < dateB) {
-      return 1
-    }
-    return 0
-  } else {
-    if (versionA > versionB) {
-      return -1
-    }
-    if (versionA < versionB) {
-      return 1
-    }
-    return 0
+  if (dateA > dateB) {
+    return -1
   }
+  if (dateA < dateB) {
+    return 1
+  }
+  return 0
 }
 
 module.exports = {

--- a/server/db/games.js
+++ b/server/db/games.js
@@ -6,25 +6,53 @@ const knex = require('./connect').knex
  * Queries for all relevant games for a specified team name. Only retrieves
  * games for the highest submission version
  * @param teamName String, name of the team to grab submissions for
+ * @param page number, desired page
+ * @param pageSize number, size of each page
  * @return {Promise} resolves when there are no errors, rejects if there is a
  *  problem
  */
-function getGamesByTeamName (teamName) {
+function getGamesByTeamName (teamName, page, pageSize) {
   return new Promise((resolve, reject) => {
     if (teamName === null || typeof teamName === 'undefined') {
       reject(new Error('TeamName is null or undefined'))
     }
     const gameIDs = []
+    const versions = []
+    /*
+      Here we join all the tables together to get a list of ids from
+      the games table that we will use in the next query.
+      We then limit how many rows we are getting by created_at,
+      and then limiting them to one pageSize worth of games,
+      offset to the specific page we want.
+      We also use this to get the version number of the submission
+      that the given teamName submitted.
+    */
     const gamesQuery = knex('games')
       .join('games_submissions', 'games_submissions.game_id', '=', 'games.id')
       .join('submissions',
         'submissions.id', '=', 'games_submissions.submission_id')
       .join('teams', 'teams.id', '=', 'submissions.team_id')
       .where('teams.name', '=', teamName)
-      .select('games.id', 'games.created_at', 'games.updated_at')
+      .select('games.id', 'games.created_at', 'games.updated_at',
+        'submissions.version')
+      .orderBy('games.created_at', 'desc')
+      .limit(pageSize).offset((page - 1) * pageSize)
     gamesQuery.then((rows) => {
       // This gets the IDs for each game that the user is in
       rows.forEach((row) => { gameIDs.push(row.id) })
+      // Get a list of versions associated with game IDs
+      rows.forEach((row) => {
+        versions.push({
+          gameID: row.id,
+          version: row.version
+        })
+      })
+      /*
+       Here we join all of the tables together, limiting it to the
+       gameIDs we found in the earlier query, as well as only looking
+       for rows where the team name is not the same as our given name
+       because we are only looking for the opponents name
+      */
       const submissions = knex('submissions')
         .join('games_submissions',
           'games_submissions.submission_id', '=', 'submissions.id')
@@ -34,7 +62,6 @@ function getGamesByTeamName (teamName) {
         .select('submissions.team_id',
           'games.id',
           'teams.name',
-          'submissions.version',
           'games.status',
           'games.win_reason',
           'games.lose_reason',
@@ -42,27 +69,29 @@ function getGamesByTeamName (teamName) {
           'games.log_url',
           'games.created_at',
           'games.updated_at')
+        .where('teams.name', '!=', teamName)
+
       submissions.then((subRows) => {
+        console.log(subRows)
         const games = []
         for (const row of subRows) {
           let game = row
-          if (row.name !== teamName) {
-            // This finds the other row describing this game but with the
-            // team name of what we were given, so we have the correct version
-            let ver = subRows.find(o => o.name === teamName && o.id === row.id)
-            game.version = ver.version
-            game.opponent = row.name
-            delete game.name
-            if (game.team_id === game.winner_id) {
-              game.winner = game.opponent
-            } else {
-              game.winner = teamName
-            }
-            delete game.winner_id
-            delete game.team_id
-            games.push(game)
+          // This finds the version number of the teamName we searched for
+          // By using the array we made earlier to store them together
+          let ver = versions.find(o => o.gameID === row.id)
+          game.version = ver.version
+          game.opponent = row.name
+          delete game.name
+          if (game.team_id === game.winner_id) {
+            game.winner = game.opponent
+          } else {
+            game.winner = teamName
           }
+          delete game.winner_id
+          delete game.team_id
+          games.push(game)
         }
+        // We need to re-sort the games
         games.sort(sortGames)
         return resolve(games)
       })

--- a/server/db/games.js
+++ b/server/db/games.js
@@ -18,6 +18,9 @@ function getGamesByTeamName (teamName, page, pageSize) {
     }
     const gameIDs = []
     const versions = []
+    // This is the offset for the query, it subtracts 1 from the page
+    // so that page 1 causes it to be 0, which will work like it isn't there
+    const offset = (page - 1) * pageSize
     /*
       Here we join all the tables together to get a list of ids from
       the games table that we will use in the next query.
@@ -36,7 +39,7 @@ function getGamesByTeamName (teamName, page, pageSize) {
       .select('games.id', 'games.created_at', 'games.updated_at',
         'submissions.version')
       .orderBy('games.created_at', 'desc')
-      .limit(pageSize).offset((page - 1) * pageSize)
+      .limit(pageSize).offset(offset)
     gamesQuery.then((rows) => {
       // This gets the IDs for each game that the user is in
       rows.forEach((row) => { gameIDs.push(row.id) })

--- a/server/db/games.js
+++ b/server/db/games.js
@@ -107,14 +107,14 @@ function getGameById (gameId) {
       return reject(new Error('gameId is null or undefined'))
     }
     knex
-    .select('status', 'win_reason', 'lose_reason', 'winner_id', 'log_url')
-    .from('games')
-    .where('id', '=', gameId)
-    .then((res) => {
-      return resolve(res)
-    }).catch((err) => {
-      return reject(err)
-    })
+      .select('status', 'win_reason', 'lose_reason', 'winner_id', 'log_url')
+      .from('games')
+      .where('id', '=', gameId)
+      .then((res) => {
+        return resolve(res)
+      }).catch((err) => {
+        return reject(err)
+      })
   })
 }
 

--- a/server/db/games.js
+++ b/server/db/games.js
@@ -75,7 +75,6 @@ function getGamesByTeamName (teamName, page, pageSize) {
         .where('teams.name', '!=', teamName)
 
       submissions.then((subRows) => {
-        console.log(subRows)
         const games = []
         for (const row of subRows) {
           let game = row

--- a/server/routers/games.js
+++ b/server/routers/games.js
@@ -4,31 +4,55 @@ const express = require('express')
 const router = express.Router()
 const games = require('../db/init').games
 
-// How many games should be in each page
-const PAGE_SIZE = 100
-
 // All paths in this file should start with this
 const path = '/games'
 
+/**
+ * Expects URL parameters
+ *  page: The requested page
+ *  pageSize: How many games desired on each page
+ * Responds with a body of the form:
+ *{
+    success: false,
+    message: '',
+    pages: 0,
+    games: []
+  }
+ * Response codes:
+ * 200 Successfully returned games
+ * 400 Bad input, missing fields
+ * 401 Unauthorized, not signed in
+ * 500 Server error
+ */
 router.get(path + '/', (req, res) => {
-  // This is the signed in user, retrieved from the jwt
-  const teamName = req.user.username
-  const page = req.query.page
   const response = {
     success: false,
     message: '',
     pages: 0,
     games: []
   }
-  if (typeof page === 'undefined' || page === null) {
-    // We need the page number in order to move on
-    response.message = 'No page number included (param name: page)'
-    return res.status(400).json(response)
+  // Check for the existence of required parameters, and make sure that
+  // they are passed as positive numbers
+  const requiredValues = ['page', 'pageSize']
+  for (const value of requiredValues) {
+    let param = req.query[value]
+    if (typeof param === 'undefined') {
+      response.message = 'Required field ' + value + ' is missing or blank'
+      return res.status(400).json(response)
+    } else if (typeof param !== 'number' && param <= 0) {
+      response.message = value + ' must be a positive number'
+      return res.status(400).json(response)
+    }
   }
+  // This is the signed in user, retrieved from the jwt
+  const teamName = req.user.username
+  // The specific page requested
+  const page = req.query.page
+  // How many games should be in each page
+  const pageSize = req.query.pageSize
 
-  // if user is auth'ed:
   games.getGamesByTeamName(teamName).then((games) => {
-    const paginatedGames = createGroupedArray(games, PAGE_SIZE)
+    const paginatedGames = createGroupedArray(games, pageSize)
     if (paginatedGames.length === 0) {
       return res.status(200).json(response)
     } else if (page > paginatedGames.length) {

--- a/server/routers/games.js
+++ b/server/routers/games.js
@@ -51,19 +51,20 @@ router.get(path + '/', (req, res) => {
   // How many games should be in each page
   const pageSize = req.query.pageSize
 
-  games.getGamesByTeamName(teamName).then((games) => {
+  games.getGamesByTeamName(teamName, page, pageSize).then((games) => {
     const paginatedGames = createGroupedArray(games, pageSize)
     if (paginatedGames.length === 0) {
       return res.status(200).json(response)
     } else if (page > paginatedGames.length) {
-      response.message = 'Incorrect page number'
-      return res.status(400).json(response)
+      // response.message = 'Incorrect page number'
+      // return res.status(400).json(response)
     }
     response.success = true
     response.message = 'Games successfully retrieved'
     response.pages = paginatedGames.length
     // page - 1 because the array is indexed at 0
-    response.games = paginatedGames[page - 1]
+    // response.games = paginatedGames[page - 1]
+    response.games = games
     return res.status(200).json(response)
   }).catch((err) => {
     response.message = 'An error occurred: ' + err.message


### PR DESCRIPTION
This changes how the server grabs games considerably. Instead of wastefully grabbing every game and then breaking it down, it only grabs the games requested. 

This also adds a new parameter to the GET /games endpoint, pageSize, which allows the caller to define how large they want the page to be

The pages are also now only sorted by created_at, both because I think it makes more sense to always put them in sequential order, and if we implement a versioning system for submissions in the future, this will be necessary