### PR TITLE
Persist state of Auth Store and add more client validation for jwt tokens

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -5873,6 +5873,11 @@
       "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-1.4.1.tgz",
       "integrity": "sha1-OGchPo3Xm/Ho8jAMDPwe+xgsDfE="
     },
+    "jwt-decode": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-2.2.0.tgz",
+      "integrity": "sha1-fYa9VmefWM5qhHBKZX3TkruoGnk="
+    },
     "keycode": {
       "version": "2.1.9",
       "resolved": "https://registry.npmjs.org/keycode/-/keycode-2.1.9.tgz",

--- a/client/package.json
+++ b/client/package.json
@@ -29,6 +29,7 @@
     "fs-extra": "3.0.1",
     "html-webpack-plugin": "2.29.0",
     "jest": "20.0.4",
+    "jwt-decode": "^2.2.0",
     "mobx": "^3.4.1",
     "mobx-react": "^4.3.5",
     "object-assign": "4.1.1",

--- a/client/src/stores/auth.js
+++ b/client/src/stores/auth.js
@@ -1,41 +1,76 @@
 import axios from 'axios'
-import { action, computed, observable, reaction } from 'mobx'
+import { action, computed, observable, reaction, toJS, autorun, extendObservable } from 'mobx'
+import jwtDecode from 'jwt-decode'
 
 import gameStore from './games'
 import submissionStore from './submissions'
 
+/**
+ * @description If the value of any observables change, save the new values in localStorage. Does not save on initial load
+ * @param {any} store Any instance of a store
+ * @param {function} save Function that will save store values in localStorage
+ */
+function autoSave (store, save) {
+  let firstRun = true;
+  autorun(() => {
+    // This code will run every time any observable property
+    // on the store is updated.
+    const json = JSON.stringify(toJS(store));
+    if (!firstRun) {
+      save(json);
+    }
+    firstRun = false;
+  })
+}
+
 export class AuthStore {
   @observable username = ''
-  @observable token = window.localStorage.getItem('jwt')
+  @observable token = ''
 
   constructor () {
-    // Updates or removes our JSON Web Token in the localStorage of the browser.1
+    // Removes the auth JSON value in localStorage if the user is no longer logged in
     reaction(
-      () => this.token,
-      token => {
-        if (token) {
-          window.localStorage.setItem('jwt', token)
-        } else {
-          window.localStorage.removeItem('jwt')
+      () => this.isUserLoggedIn,
+      isUserLoggedIn => {
+        if (!isUserLoggedIn) {
+          localStorage.removeItem('auth')
         }
       }
     )
+
+    this.loadUser();
+    autoSave(this, this.save)
   }
 
+  /**
+   * @description Decode token and validate user's authentication
+   * @return {boolean} True if user has a valid token. Otherwise, false
+   */
   @computed get isUserLoggedIn () {
-    return !!(this.token)
+    try {
+      const { exp, username } = jwtDecode(this.token)
+
+      if (this.isTokenExpired(exp) || this.username !== username) {
+        return false
+      }
+    } catch (err) {
+      return false
+    }
+
+    return true
   }
 
-  @action setToken(token) {
+  @action setToken (token) {
     this.token = token
   }
 
-  @action setUsername(username) {
+  @action setUsername (username) {
     this.username = username
   }
 
   @action logUserIn (username, password) {
-    return new Promise(action('login-callback', (resolve, reject) => {      axios.post('/login',
+    return new Promise(action('login-callback', (resolve, reject) => {
+      axios.post('/login',
         {
           username: username,
           password: password
@@ -57,6 +92,36 @@ export class AuthStore {
     this.token = ''
     gameStore.resetGameData()
     submissionStore.resetSubmissionData()
+  }
+
+  /**
+   * @description Check whether or not the token is expired
+   * @param {number} exp Value in UTC seconds when token expires
+   * @return {boolean} Whether or not the token has expired compared to the current time
+   */
+  isTokenExpired (exp) {
+    if (!exp) {
+      return false
+    }
+    return new Date().getTime() / 1000 > exp
+  }
+
+  /**
+   * @description Get and update values of the auth store in localStorage
+  */
+  loadUser () {
+    const auth = localStorage.getItem('auth');
+    if (auth) {
+      extendObservable(this, JSON.parse(auth));
+    }
+  }
+
+  /**
+   * @description Save the JSON value of the store in localStorage
+   * @param {string} json stringified JSON object of the store
+   */
+  save = (json) => {
+    localStorage.setItem('auth', json)
   }
 }
 


### PR DESCRIPTION
This also fixed a bug with the username in the Auth Store being cleared if the page was refreshed because Mobx does not natively persist app state upon refresh.

I just saved the values of the entire auth store in localStorage and when the values are changed, it updates the auth store in localStorage. When the auth store is created, it grabs its previous state in localStorage.